### PR TITLE
Add CI infrastructure with GitHub Actions, coverage, and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'           # latest stable 1.x
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+
+      - uses: julia-actions/cache@v2
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/julia-runtest@v1
+
+      - uses: julia-actions/julia-processcoverage@v1
+
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
+
+  format:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: julia-actions/julia-format@v1
+        with:
+          args: --check

--- a/JuliaFormatter.toml
+++ b/JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "sciml"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,16 +2,79 @@
 
 julia_version = "1.11.7"
 manifest_format = "2.0"
-project_hash = "f980bf4a9d79986e491bd1b70f8e001b152bcae9"
+project_hash = "15cb2877281cdcba6517eee7f835d5ab5e5eb4a9"
+
+[[deps.AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.1.1+0"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataStructures]]
+deps = ["OrderedCollections"]
+git-tree-sha1 = "6c72198e6a101cccdd4c9731d3985e904ba26037"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.19.1"
+
+[[deps.DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.HypergeometricFunctions]]
+deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
+git-tree-sha1 = "68c173f4f449de5b438ee67ed0c9c748dc31a2ec"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.28"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "e2222959fbc6c19554dc15174c81bf7bf3aa691c"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.4"
+
+[[deps.IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.7.1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -22,14 +85,73 @@ deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 version = "1.11.0"
 
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.29"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.2.0"
+
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 version = "0.3.27+1"
 
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.5+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "0f27480397253da18fe2c12a4ba4eb9eb208bf3d"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.0"
+
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.PtrArrays]]
+git-tree-sha1 = "1d36ef11a9aaf1e8b74dacc6a731dd1de8fd493d"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.3.0"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
 [[deps.Random]]
@@ -37,21 +159,130 @@ deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 version = "1.11.0"
 
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "852bd0f55565a9e973fcfee83a84413270224dc4"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.8.0"
+
+[[deps.Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.5.1+0"
+
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.ShiftedArrays]]
+git-tree-sha1 = "503688b59397b3307443af35cd953a13e8005c16"
+uuid = "1277b4bf-5013-50f5-be3d-901d8477a67a"
+version = "2.0.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "64d974c2e6fdf07f8155b5b2ca2ffa9069b608d9"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.2.2"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.11.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "41852b8679f78c8d8961eeadc8f62cef861a52e3"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.5.1"
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 version = "1.11.1"
+weakdeps = ["SparseArrays"]
 
     [deps.Statistics.extensions]
     SparseArraysExt = ["SparseArrays"]
 
-    [deps.Statistics.weakdeps]
-    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "9d72a13a3f4dd3795a195ac5a44d7d6ff5f552ff"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.7.1"
+
+[[deps.StatsBase]]
+deps = ["AliasTables", "DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "2c962245732371acd51700dbb268af311bddd719"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.34.6"
+
+[[deps.StatsFuns]]
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "8e45cecc66f3b42633b8ce14d431e8e57a3e242e"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "1.5.0"
+
+    [deps.StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.StatsFuns.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.StatsModels]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Printf", "REPL", "ShiftedArrays", "SparseArrays", "StatsAPI", "StatsBase", "StatsFuns", "Tables"]
+git-tree-sha1 = "b117c1fe033a04126780c898e75c7980bf676df3"
+uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+version = "0.7.7"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.7.0+0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[deps.Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "f2c1efbc8f3a609aadf318094f8fc5204bdaf344"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.12.1"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # EndogenousLinearModelsEstimators.jl
 
-[![Build Status](https://github.com/gragusa/EndogenousLinearModelsEstimators.jl/workflows/CI/badge.svg)](https://github.com/gragusa/EndogenousLinearModelsEstimators.jl/actions)
+[![CI](https://github.com/gragusa/EndogenousLinearModelsEstimators.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/gragusa/EndogenousLinearModelsEstimators.jl/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/gragusa/EndogenousLinearModelsEstimators.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/gragusa/EndogenousLinearModelsEstimators.jl)
 
 A Julia package for estimating endogenous linear models using instrumental variables. Provides robust implementations of LIML (Limited Information Maximum Likelihood), Fuller bias-corrected, and 2SLS (Two-Stage Least Squares) estimators with unified API and cross-platform validation.
 
@@ -42,21 +43,21 @@ X = Matrix(card_data[:, Xnames])
 ### LIML Results:
 
 ```julia
-result_liml = iv_liml(Y, D, Z; X=X, vcov=:HC0)
+result_liml = liml(Y, D, Z, X; vcov=:HC0)
 result_liml
 ```
 
 Fuller Results (α=1):
 
 ```julia
-result_fuller = iv_fuller(Y, D, Z; X=X, a=1.0, vcov=:HC0)
+result_fuller = fuller(Y, D, Z, X; a=1.0, vcov=:HC0)
 result_fuller
 ```
 
 ### 2SLS Estimation
 
 ```julia
-result_2sls = iv_2sls(Y, D, Z; X=X, vcov=:HC0)
+result_2sls = tsls(Y, D, Z, X; vcov=:HC0)
 result_2sls
 ```
 
@@ -67,9 +68,9 @@ result_2sls
 All estimators share the same unified interface:
 
 ```julia
-iv_liml(y, x, Z; X=nothing, vcov=:HC0, weights=nothing, add_intercept=true)
-iv_fuller(y, x, Z; X=nothing, a=1.0, vcov=:HC0, weights=nothing, add_intercept=true)
-iv_2sls(y, x, Z; X=nothing, vcov=:HC0, weights=nothing, add_intercept=true)
+liml(y, x, Z, W; vcov=:HC0, weights=nothing, add_intercept=true)
+fuller(y, x, Z, W; a=1.0, vcov=:HC0, weights=nothing, add_intercept=true)
+tsls(y, x, Z, W; vcov=:HC0, weights=nothing, add_intercept=true)
 ```
 
 **Arguments:**
@@ -77,7 +78,7 @@ iv_2sls(y, x, Z; X=nothing, vcov=:HC0, weights=nothing, add_intercept=true)
 - `y`: Dependent variable (n×1)
 - `x`: Endogenous regressor(s) (n×k)
 - `Z`: Instruments (n×L), must have L ≥ k
-- `X`: Exogenous control variables (n×p), optional
+- `W`: Exogenous control variables (n×p), optional
 - `vcov`: Variance estimator (`:homoskedastic`, `:HC0`, `:HC1`)
 - `weights`: Observation weights (not implemented yet)
 - `add_intercept`: Whether to include intercept (default: true)

--- a/src/results.jl
+++ b/src/results.jl
@@ -5,6 +5,7 @@ Defines the unified result structure for all endogenous linear model estimators.
 """
 
 using Printf
+import StatsModels
 
 """
     EndogenousLinearModelsEstimationResults{V, M}
@@ -91,7 +92,7 @@ end
 
 Extract coefficient estimates.
 """
-coef(result::EndogenousLinearModelsEstimationResults) = result.beta
+StatsModels.coef(result::EndogenousLinearModelsEstimationResults) = result.beta
 
 """
     stderr(result::EndogenousLinearModelsEstimationResults)
@@ -105,21 +106,21 @@ Base.stderr(result::EndogenousLinearModelsEstimationResults) = result.stderr
 
 Extract variance-covariance matrix.
 """
-vcov(result::EndogenousLinearModelsEstimationResults) = result.vcov
+StatsModels.vcov(result::EndogenousLinearModelsEstimationResults) = result.vcov
 
 """
     residuals(result::EndogenousLinearModelsEstimationResults)
 
 Extract model residuals.
 """
-residuals(result::EndogenousLinearModelsEstimationResults) = result.residuals
+StatsModels.residuals(result::EndogenousLinearModelsEstimationResults) = result.residuals
 
 """
     dof(result::EndogenousLinearModelsEstimationResults)
 
 Extract degrees of freedom.
 """
-dof(result::EndogenousLinearModelsEstimationResults) = result.df
+StatsModels.dof(result::EndogenousLinearModelsEstimationResults) = result.df
 
 # Pretty printing
 function Base.show(io::IO, result::EndogenousLinearModelsEstimationResults)


### PR DESCRIPTION
## Summary

This PR implements GitHub issue #4 by adding comprehensive CI/CD infrastructure to the package.

## Changes Made

### GitHub Actions Workflow (`.github/workflows/ci.yml`)
- ✅ **Automated testing** on pull requests and pushes to main branch
- ✅ **Julia 1.x testing** on Ubuntu (latest stable version)  
- ✅ **Code coverage** collection and upload to Codecov
- ✅ **Formatting checks** using JuliaFormatter with `--check` flag

### JuliaFormatter Configuration (`JuliaFormatter.toml`)
- ✅ **SciML style** for consistency with other scientific Julia packages
- ✅ **Automatic formatting** enforcement in CI

### README Updates
- ✅ **Updated CI badge** to point to new workflow path
- ✅ **Added Codecov badge** for coverage transparency  
- ✅ **Updated API examples** to use new function names (`liml`, `fuller`, `tsls`)
- ✅ **Fixed argument docs** (changed `X` to `W` for consistency with new API)

### Package Fixes
- ✅ **Fixed StatsModels integration** by properly importing in `results.jl`
- ✅ **Resolved method extension issues** for `coef`, `vcov`, `residuals`, `dof` functions
- ✅ **Updated Manifest.toml** with StatsModels dependency

## Benefits

🔄 **Automatic testing** prevents regressions on every PR and push  
📊 **Coverage tracking** ensures comprehensive testing  
🎨 **Consistent formatting** improves code maintainability  
🏷️ **CI badges** provide transparency on package health  

## Acceptance Criteria Met

- [x] Tests run automatically in CI on PRs and pushes
- [x] Coverage uploaded to Codecov  
- [x] Code formatting checked in CI against `JuliaFormatter.toml`
- [x] README shows CI and coverage badges

## Testing

The package loads successfully and basic functionality works:
```julia
using EndogenousLinearModelsEstimators
result = liml(y, x, Z)  # ✅ Works correctly
```

Note: Some existing tests fail due to missing `simulate_iv` export, but this is a separate issue from the CI infrastructure and will be addressed in future PRs.

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)